### PR TITLE
Fix the action switch for changing the PST channel.

### DIFF
--- a/index.js
+++ b/index.js
@@ -410,7 +410,7 @@ instance.prototype.action = function(action) {
 		case 'select_pgm':
 			cmd = '\u0002PGM:' + options.source + ';';
 			break;
-		case 'select_pvw':
+		case 'select_pst':
 			cmd = '\u0002PST:' + options.source + ';';
 			break;
 		case 'select_aux':

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "roland-v600uhd",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"api_version": "1.0.0",
 	"keywords": [ "Vision Mixer" ],
 	"manufacturer": "Roland",


### PR DESCRIPTION
The action name in the instance action for changing the PST channel was defined as "select_pst" but the switch statement to perform the action was defined as "select_pvw". This change matches the two so the command will execute.