### PR TITLE
Fix actions.select_aux using incorrect options dropdown

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -45,10 +45,10 @@ module.exports = {
 			options: [
 				{
 					type: 'dropdown',
-					label: 'Transition Pattern',
-					id: 'transitionpattern',
+					label: 'Source',
+					id: 'source',
 					default: '0',
-					choices: self.CHOICES_TRANSITION_PATTERNS
+					choices: self.CHOICES_INPUTS
 				}
 			],
 			callback: async (action) => {


### PR DESCRIPTION
Fix for issue #8 Select AUX Channel action is incorrectly prompting for transition type rather than input source

Updated actions.js to use the correct choices dropdown.

Manually applied and tested the code changes against a Roland V-600UHD.